### PR TITLE
pin version to <1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM hackinglab/alpine-base:3.2 as builder
 MAINTAINER Manfred Kaiser <manfred.kaiser@ssh-mitm.at>
 
 RUN apk add openssh-keygen python3 py3-pip py3-cryptography py3-pynacl py3-bcrypt && \
-    pip3 install ssh-mitm
+    pip3 install "ssh-mitm<1.0"
 
 # Add the files
 ADD root /


### PR DESCRIPTION
I have pinned the versio to ssh-mitm<1.0

The next release will be incompatible with the current release and some things can break.
For example I have changed the behavior of some command line arguments, like "--remote-host", which you are using.